### PR TITLE
feat: add screen param to desktop_click, desktop_scroll, desktop_ocr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,17 @@
 {
   "name": "codriver-mcp",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codriver-mcp",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
+      "os": [
+        "darwin",
+        "win32"
+      ],
       "dependencies": {
         "@jitsi/robotjs": "^0.6.21",
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/src/modules/input-controller.ts
+++ b/src/modules/input-controller.ts
@@ -8,6 +8,7 @@ import robot from '@jitsi/robotjs';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { ClickOptions, TypeOptions, KeyOptions, ScrollOptions, DragOptions } from '../types/index.js';
+import { screenCapture } from './screen-capture.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -83,8 +84,14 @@ export class InputController {
    * Uses Swift/CGEvent for reliable mouse control on macOS Sequoia.
    */
   async click(options: ClickOptions): Promise<void> {
-    const { coordinate, button = 'left', doubleClick = false } = options;
-    const [x, y] = coordinate;
+    const { coordinate, button = 'left', doubleClick = false, screen } = options;
+    let [x, y] = coordinate;
+
+    if (screen != null) {
+      const [ox, oy] = await screenCapture.getDisplayOrigin(screen);
+      x += ox;
+      y += oy;
+    }
 
     if (process.platform === 'darwin') {
       await this.clickMacOS(x, y, button, doubleClick);
@@ -173,8 +180,14 @@ export class InputController {
    * Uses Swift/CGEvent on macOS for mouse positioning.
    */
   async scroll(options: ScrollOptions): Promise<void> {
-    const { coordinate, direction, amount = 3 } = options;
-    const [x, y] = coordinate;
+    const { coordinate, direction, amount = 3, screen } = options;
+    let [x, y] = coordinate;
+
+    if (screen != null) {
+      const [ox, oy] = await screenCapture.getDisplayOrigin(screen);
+      x += ox;
+      y += oy;
+    }
 
     if (process.platform === 'darwin') {
       await this.scrollMacOS(x, y, direction, amount);

--- a/src/modules/ocr-engine.ts
+++ b/src/modules/ocr-engine.ts
@@ -12,11 +12,11 @@ export class OcrEngine {
    * Extract text from a screen region using OCR.
    * Takes a screenshot of the region and runs Tesseract on it.
    */
-  async recognize(options: { region?: Region; language?: string } = {}): Promise<OcrResult> {
-    const { region, language = 'eng' } = options;
+  async recognize(options: { region?: Region; language?: string; screen?: number } = {}): Promise<OcrResult> {
+    const { region, language = 'eng', screen } = options;
 
-    // Capture screenshot (optionally cropped to region)
-    const screenshot = await screenCapture.capture({ region, format: 'png' });
+    // Capture screenshot (optionally cropped to region, from a specific display)
+    const screenshot = await screenCapture.capture({ region, format: 'png', screen });
     const imageBuffer = Buffer.from(screenshot.data, 'base64');
 
     const result = await Tesseract.recognize(imageBuffer, language);

--- a/src/modules/screen-capture.ts
+++ b/src/modules/screen-capture.ts
@@ -10,6 +10,9 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from '
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 import { createRequire } from 'node:module';
 import type { ScreenshotOptions, ScreenshotResult, DisplayInfo } from '../types/index.js';
 
@@ -146,6 +149,44 @@ export class ScreenCapture {
   async listDisplays(): Promise<DisplayInfo[]> {
     const displays = await screenshot.listDisplays();
     return displays.map((d) => ({ id: d.id, name: d.name }));
+  }
+
+  /**
+   * Get the global Quartz origin (x, y) of a display by its ID.
+   * Used to convert screen-relative coordinates to global coordinates for input events.
+   * macOS only - returns [0, 0] on other platforms.
+   */
+  async getDisplayOrigin(screenId: number): Promise<[number, number]> {
+    if (process.platform !== 'darwin') return [0, 0];
+
+    try {
+      // Use CoreGraphics to get display bounds in Quartz coordinates (origin at top-left)
+      const script = [
+        'import CoreGraphics',
+        'var count: UInt32 = 0',
+        'CGGetActiveDisplayList(0, nil, &count)',
+        'var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))',
+        'CGGetActiveDisplayList(count, &ids, &count)',
+        'for id in ids {',
+        '    let b = CGDisplayBounds(id)',
+        '    print("\\(id),\\(Int(b.origin.x)),\\(Int(b.origin.y))")',
+        '}',
+      ].join('\n');
+
+      const { stdout } = await execFileAsync('swift', ['-e', script], { timeout: 10000 });
+
+      for (const line of stdout.trim().split('\n')) {
+        const parts = line.split(',');
+        if (parts.length === 3) {
+          const [id, x, y] = parts.map(Number);
+          if (id === screenId) return [x, y];
+        }
+      }
+    } catch {
+      // Fall through to default if Swift unavailable
+    }
+
+    return [0, 0];
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,12 +108,16 @@ export function createServer(): McpServer {
           .boolean()
           .optional()
           .describe('Double-click instead of single click'),
+        screen: z
+          .number()
+          .optional()
+          .describe('Display ID (from desktop_displays). When set, x/y are relative to that display - matching coordinates from desktop_screenshot with the same screen param. On macOS, offsets are resolved automatically via CGDisplayBounds.'),
       },
       annotations: {
         destructiveHint: true,
       },
     },
-    async ({ x, y, ref, button, doubleClick }) => {
+    async ({ x, y, ref, button, doubleClick, screen }) => {
       let clickX: number;
       let clickY: number;
       let targetDesc: string;
@@ -144,6 +148,7 @@ export function createServer(): McpServer {
         coordinate: [clickX, clickY],
         button: button ?? 'left',
         doubleClick: doubleClick ?? false,
+        screen,
       });
 
       return {
@@ -260,13 +265,18 @@ export function createServer(): McpServer {
           .max(20)
           .optional()
           .describe('Number of scroll ticks. Default: 3'),
+        screen: z
+          .number()
+          .optional()
+          .describe('Display ID (from desktop_displays). When set, x/y are relative to that display - matching coordinates from desktop_screenshot with the same screen param.'),
       },
     },
-    async ({ x, y, direction, amount }) => {
+    async ({ x, y, direction, amount, screen }) => {
       await inputController.scroll({
         coordinate: [x, y],
         direction,
         amount: amount ?? 3,
+        screen,
       });
       return {
         content: [
@@ -568,17 +578,21 @@ export function createServer(): McpServer {
         width: z.number().optional().describe('Region width'),
         height: z.number().optional().describe('Region height'),
         language: z.string().optional().describe('OCR language code (e.g. "eng", "deu"). Default: eng.'),
+        screen: z
+          .number()
+          .optional()
+          .describe('Display ID (from desktop_displays). When set, OCR runs on that specific display instead of the primary screen. Use desktop_displays to list available monitors.'),
       },
       annotations: {
         readOnlyHint: true,
       },
     },
-    async ({ x, y, width, height, language }) => {
+    async ({ x, y, width, height, language, screen }) => {
       const region = (x != null && y != null && width != null && height != null)
         ? [x, y, width, height] as [number, number, number, number]
         : undefined;
 
-      const result = await ocrEngine.recognize({ region, language: language ?? 'eng' });
+      const result = await ocrEngine.recognize({ region, language: language ?? 'eng', screen });
 
       return {
         content: [{

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,8 @@ export interface ClickOptions {
   coordinate: Coordinate;
   button?: MouseButton;
   doubleClick?: boolean;
+  /** If set, coordinate is relative to this display (matches desktop_screenshot screen param) */
+  screen?: number;
 }
 
 /** Type options */
@@ -68,6 +70,8 @@ export interface ScrollOptions {
   coordinate: Coordinate;
   direction: ScrollDirection;
   amount?: number;
+  /** If set, coordinate is relative to this display (matches desktop_screenshot screen param) */
+  screen?: number;
 }
 
 /** Drag options */


### PR DESCRIPTION
Relates to #1.

## Problem

On multi-monitor setups, \`desktop_screenshot\` already accepts a \`screen\` param and returns screen-relative coordinates (0→width, 0→height for that display). But \`desktop_click\`, \`desktop_scroll\`, and \`desktop_ocr\` only work in global coordinates.

This creates a constant mismatch: you take a screenshot of screen 1, spot a button at (800, 400), but you can't pass those coordinates directly to \`desktop_click\` — you have to manually calculate the global offset for that display. On a MacBook + external monitor setup this means figuring out display arrangement, retina scaling, and AppKit vs Quartz coordinate systems. It's error-prone and forces multiple failed attempts per session.

## Solution

Add an optional \`screen\` parameter to \`desktop_click\`, \`desktop_scroll\`, and \`desktop_ocr\`. When provided, coordinates are interpreted as screen-relative and converted to global automatically.

**Usage (before):**
```
desktop_screenshot(screen: 1)  → sees button at (800, 400) in the image
desktop_click(x: 2240, y: 1300)  ← had to manually calculate global offset
```

**Usage (after):**
```
desktop_screenshot(screen: 1)  → sees button at (800, 400) in the image
desktop_click(x: 800, y: 400, screen: 1)  ← just works
```

## Changes

- **`src/types/index.ts`** — add `screen?: number` to `ClickOptions` and `ScrollOptions`
- **`src/modules/screen-capture.ts`** — add `getDisplayOrigin(screenId)` method: uses Swift/CoreGraphics (`CGDisplayBounds`) to get the Quartz origin of a display, same execution pattern as the existing mouse code
- **`src/modules/input-controller.ts`** — import `screenCapture`, resolve display offset in `click()` and `scroll()` when `screen` is set
- **`src/modules/ocr-engine.ts`** — pass `screen` through to `screenCapture.capture()` (which already supports it)
- **`src/server.ts`** — expose `screen` param on `desktop_click`, `desktop_scroll`, `desktop_ocr` tool definitions

## Notes

- `getDisplayOrigin` falls back to `[0, 0]` if Swift is unavailable (non-macOS or broken toolchain), so existing behaviour is preserved
- `CGDirectDisplayID` values match what `screenshot-desktop` returns as `display.id` on macOS, so the same ID works across both tools
- No new dependencies added